### PR TITLE
Minor improvements to feature/scan-compile-run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: push
+on: [ push, pull_request ]
 
 jobs:
   build:

--- a/include/core/command_facade.hpp
+++ b/include/core/command_facade.hpp
@@ -17,7 +17,7 @@ private:
 
 public:
     CommandFacade();
-    void parse(string const &command);
+    std::function<void()> parse(string const &command);
 };
 
 #endif

--- a/include/core/command_facade.hpp
+++ b/include/core/command_facade.hpp
@@ -1,16 +1,21 @@
 #ifndef COMMAND_PARSER_HPP
 #define COMMAND_PARSER_HPP
 
+#include <map>
+
 #include <bits/stdc++.h>
 #include "assert.hpp"
 #include "scanner.hpp"
 #include "runner.hpp"
 #include "../types.hpp"
 
+using CommandMap = std::map<std::string, std::function<void()>>;
+
 class CommandFacade
 {
 private:
     Assert *assert;
+    CommandMap commands;
 
     void self_test();
     void test();
@@ -18,6 +23,7 @@ private:
 public:
     CommandFacade();
     std::function<void()> parse(string const &command);
+    std::vector<std::string> list_commands();
 };
 
 #endif

--- a/include/core/command_facade.hpp
+++ b/include/core/command_facade.hpp
@@ -11,19 +11,16 @@
 
 using CommandMap = std::map<std::string, std::function<void()>>;
 
-class CommandFacade
+namespace command_facade
 {
-private:
-    Assert *assert;
-    CommandMap commands;
+    extern Assert *assert;
+    extern CommandMap commands;
+
+    std::function<void()> parse(string const &command);
+    std::vector<std::string> list_commands();
 
     void self_test();
     void test();
-
-public:
-    CommandFacade();
-    std::function<void()> parse(string const &command);
-    std::vector<std::string> list_commands();
-};
+}
 
 #endif

--- a/src/core/command_facade.cpp
+++ b/src/core/command_facade.cpp
@@ -1,57 +1,57 @@
 #include "../../include/core/command_facade.hpp"
 
-CommandFacade::CommandFacade()
+namespace command_facade
 {
-    assert = Assert::get_instance();
-    commands = {
-        { "self-test", [this]() -> void { self_test(); } },
-        { "test",      [this]() -> void { test(); } }
-    };
-}
-
-std::vector<std::string> CommandFacade::list_commands()
-{
-    std::vector<std::string> keys;
-
-    keys.reserve(commands.size());
-
-    for (auto it = commands.begin(); it != commands.end(); ++it)
-        keys.push_back(it->first);
-
-    return keys;
-}
-
-void CommandFacade::self_test()
-{
-    Runner *runner = Runner::get_instance();
-    vector<string> tests = {Constants::ASSERT_TEST};
-
-    runner->process(tests);
-    runner->run(tests);
-
-    assert->show_statistics();
-}
-
-void CommandFacade::test()
-{
-    Scanner *scanner = Scanner::get_instance();
-    Runner *runner = Runner::get_instance();
-
-    vector<string> tests = scanner->scan_test_folder();
-
-    runner->process(tests);
-    runner->run(tests);
-
-    assert->show_statistics();
-}
-
-std::function<void()> CommandFacade::parse(string const &command)
-{
-    auto it = commands.find(command);
-
-    auto notfound = [command]() -> void {
-        std::cerr << "Command '" << command << "' not found." << std::endl;
+    Assert *assert = Assert::get_instance();
+    CommandMap commands = {
+        { "self_test", []() -> void { self_test(); } },
+        { "test",      []() -> void { test(); } }
     };
 
-    return (it != commands.end()) ? it->second : notfound;
+    std::function<void()> parse(string const &command)
+    {
+        auto it = commands.find(command);
+
+        auto notfound = [command]() -> void {
+            std::cerr << "Command '" << command << "' not found." << std::endl;
+        };
+
+        return (it != commands.end()) ? it->second : notfound;
+    }
+
+    std::vector<std::string> list_commands()
+    {
+        std::vector<std::string> keys;
+
+        keys.reserve(commands.size());
+
+        for (auto it = commands.begin(); it != commands.end(); ++it)
+            keys.push_back(it->first);
+
+        return keys;
+    }
+
+    void self_test()
+    {
+        Runner *runner = Runner::get_instance();
+        vector<string> tests = {Constants::ASSERT_TEST};
+
+        runner->process(tests);
+        runner->run(tests);
+
+        assert->show_statistics();
+    }
+
+    void test()
+    {
+        Scanner *scanner = Scanner::get_instance();
+        Runner *runner = Runner::get_instance();
+
+        vector<string> tests = scanner->scan_test_folder();
+
+        runner->process(tests);
+        runner->run(tests);
+
+        assert->show_statistics();
+    }
 }

--- a/src/core/command_facade.cpp
+++ b/src/core/command_facade.cpp
@@ -1,11 +1,24 @@
 #include "../../include/core/command_facade.hpp"
-#include <map>
-
-using CommandMap = std::map<std::string, std::function<void()>>;
 
 CommandFacade::CommandFacade()
 {
     assert = Assert::get_instance();
+    commands = {
+        { "self-test", [this]() -> void { self_test(); } },
+        { "test",      [this]() -> void { test(); } }
+    };
+}
+
+std::vector<std::string> CommandFacade::list_commands()
+{
+    std::vector<std::string> keys;
+
+    keys.reserve(commands.size());
+
+    for (auto it = commands.begin(); it != commands.end(); ++it)
+        keys.push_back(it->first);
+
+    return keys;
 }
 
 void CommandFacade::self_test()
@@ -34,16 +47,11 @@ void CommandFacade::test()
 
 std::function<void()> CommandFacade::parse(string const &command)
 {
-    CommandMap map = {
-        { "self-test", [this]() -> void { self_test(); } },
-        { "test",      [this]() -> void { test(); } }
-    };
-
-    auto it = map.find(command);
+    auto it = commands.find(command);
 
     auto notfound = [command]() -> void {
         std::cerr << "Command '" << command << "' not found." << std::endl;
     };
 
-    return (it != map.end()) ? it->second : notfound;
+    return (it != commands.end()) ? it->second : notfound;
 }

--- a/src/core/command_facade.cpp
+++ b/src/core/command_facade.cpp
@@ -32,7 +32,7 @@ void CommandFacade::test()
     assert->show_statistics();
 }
 
-void CommandFacade::parse(string const &command)
+std::function<void()> CommandFacade::parse(string const &command)
 {
     CommandMap map = {
         { "self-test", [this]() -> void { self_test(); } },
@@ -41,6 +41,9 @@ void CommandFacade::parse(string const &command)
 
     auto it = map.find(command);
 
-    if (it != map.end())
-        it->second();
+    auto notfound = [command]() -> void {
+        std::cerr << "Command '" << command << "' not found." << std::endl;
+    };
+
+    return (it != map.end()) ? it->second : notfound;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,7 +5,8 @@ int main(int argc, char **argv)
 	if (argc == 2)
 	{
 		CommandFacade *facade = new CommandFacade();
-		facade->parse(argv[1]);
+		auto commandFunction = facade->parse(argv[1]);
+		commandFunction();
 		delete facade;
 	}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,32 +1,23 @@
 #include "../include/core/command_facade.hpp"
 
-static CommandFacade *facade = new CommandFacade();
-
-void delete_facade()
-{
-	delete facade;
-}
-
 void usage()
 {
 	std::cerr <<
 		"This program expects the name of a command as a single "
 		"argument.\n\nAvailable commands:\n";
 
-	for (auto command : facade->list_commands())
+	for (auto command : command_facade::list_commands())
 		std::cerr << "\t" << command << "\n";
 }
 
 int main(int argc, char **argv)
 {
-	std::atexit(delete_facade);
-
 	if (argc < 2) {
 		usage();
 		return 0;
 	}
 
-	auto commandFunction = facade->parse(argv[1]);
+	auto commandFunction = command_facade::parse(argv[1]);
 	commandFunction();
 
 	return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,23 +1,33 @@
 #include "../include/core/command_facade.hpp"
 
+static CommandFacade *facade = new CommandFacade();
+
+void delete_facade()
+{
+	delete facade;
+}
+
 void usage()
 {
 	std::cerr <<
 		"This program expects the name of a command as a single "
-		"argument.\n";
+		"argument.\n\nAvailable commands:\n";
+
+	for (auto command : facade->list_commands())
+		std::cerr << "\t" << command << "\n";
 }
 
 int main(int argc, char **argv)
 {
+	std::atexit(delete_facade);
+
 	if (argc < 2) {
 		usage();
 		return 0;
 	}
 
-	CommandFacade *facade = new CommandFacade();
 	auto commandFunction = facade->parse(argv[1]);
 	commandFunction();
-	delete facade;
 
 	return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,14 +1,23 @@
 #include "../include/core/command_facade.hpp"
 
+void usage()
+{
+	std::cerr <<
+		"This program expects the name of a command as a single "
+		"argument.\n";
+}
+
 int main(int argc, char **argv)
 {
-	if (argc == 2)
-	{
-		CommandFacade *facade = new CommandFacade();
-		auto commandFunction = facade->parse(argv[1]);
-		commandFunction();
-		delete facade;
+	if (argc < 2) {
+		usage();
+		return 0;
 	}
+
+	CommandFacade *facade = new CommandFacade();
+	auto commandFunction = facade->parse(argv[1]);
+	commandFunction();
+	delete facade;
 
 	return 0;
 }


### PR DESCRIPTION
Some minor incremental improvements to the scan-compile-run flow, seeking to
improve legibility and, despite the "big design upfront" sin, allow the code to
be more smoothly extended in the future.

Proposed changes:

  - Return a function from `CommandFacade::parse()` instead of executing it.
  - Display a usage message if `./main` is invoked with no arguments.
  - Add a `list_commands()` method to list available commands and use it.

Currently a draft, pending some discussion and a little more work.
